### PR TITLE
added space char to "Today is " translation string in Hebrew

### DIFF
--- a/Rabbi Ovadiah Yosef Calendar/Localizable.xcstrings
+++ b/Rabbi Ovadiah Yosef Calendar/Localizable.xcstrings
@@ -2579,7 +2579,7 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "היום הוא"
+            "value" : "היום הוא "
           }
         }
       }


### PR DESCRIPTION
Currently, when initiating scheduleDailyNotification() with content.body = "Today is ".localized() - the hebrew string is missing a space character, which caused the notification content to look like this:

![IMG_2806](https://github.com/user-attachments/assets/873662af-414d-4d33-a17c-32da5074d663)
